### PR TITLE
support definition of multiple servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,27 @@ webrpc-gen -schema=./proto.ridl -target=github.com/webrpc/gen-openapi@v0.7.0 -ou
 ## Set custom template variables
 Change any of the following default values by passing `-option="Value"` CLI flag to webrpc-gen.
 
-| webrpc-gen -option   | Default value              | Example value              |
-|----------------------|----------------------------|----------------------------|
-| `-title`             | `{Services[0].Name} API`   | `"Example API"`              |
-| `-apiVersion`        | `""`                       | `v22.10.25`                |
-| `-serverUrl`         | `""`                       | `https://api.example.com`  |
-| `-serverDescription` | `""`                       | `"Staging API"`              |
+| webrpc-gen -option   | Default value              | Example value                                                          |
+|----------------------|----------------------------|------------------------------------------------------------------------|
+| `-title`             | `{Services[0].Name} API`   | `"Example API"`                                                        |
+| `-apiVersion`        | `""`                       | `v22.10.25`                                                            |
+| `-serverUrl`         | `""`                       | `https://api.example.com`                                              |
+| `-serverDescription` | `""`                       | `"Staging API"`                                                        |
+| `-servers`           | `""`                       | `http://localhost:8080;description,http://localhost:8081;description`  |
 
 Example:
+- server url and server description will become part of the servers format in the end to keeep it backward compatible
+- means that the result will be `server="http://localhost:8080;description,http://localhost:8081;description,https://api.example.com;Production"`
 ```
-webrpc-gen -schema=./petstore.ridl -target=github.com/webrpc/gen-openapi@v0.7.0 -out petstore.gen.yaml -title="Example webrpc API" -apiVersion="v22.11.8" -serverUrl=https://api.example.com -serverDescription="Production"
+webrpc-gen \ 
+  -schema=./petstore.ridl \ 
+  -target=github.com/webrpc/gen-openapi@v0.7.0 \ 
+  -out petstore.gen.yaml \ 
+  -title="Example webrpc API" \ 
+  -apiVersion="v22.11.8" \ 
+  -serverUrl=https://api.example.com \ 
+  -serverDescription="Production"
+  -servers="http://localhost:8080;description,http://localhost:8081;description"
 ```
 
 # Open in Swagger UI

--- a/main.go.tmpl
+++ b/main.go.tmpl
@@ -6,6 +6,7 @@
 {{- set $opts "apiVersion" (default .Opts.apiVersion "") -}}
 {{- set $opts "serverUrl" (default .Opts.serverUrl "") -}}
 {{- set $opts "serverDescription" (default .Opts.serverDescription "") -}}
+{{- set $opts "servers" (default .Opts.servers "") -}}
 
 {{- /* Print help on -help. */ -}}
 {{- if exists .Opts "help" -}}
@@ -69,11 +70,23 @@ openapi: 3.0.0
 info:
   title: '{{ get $opts "title" }}'
   version: '{{ get $opts "apiVersion" }}'
+{{ $serversInput := get $opts "servers" -}}
 {{ if or (ne (get $opts "serverUrl") "") (ne (get $opts "serverDescription") "") -}}
-servers:
-  - url: '{{ get $opts "serverUrl" }}'
-    description: '{{ get $opts "serverDescription" }}'
+  {{ if eq $serversInput "" -}}
+    {{- $serversInput = (printf "%s;%s" (get $opts "serverUrl") (get $opts "serverDescription")) -}}
+  {{ else }}
+    {{- $serversInput = (printf "%s,%s;%s" $serversInput (get $opts "serverUrl") (get $opts "serverDescription")) -}}
+  {{ end -}}
 {{ end -}}
+{{ if ne $serversInput "" -}}
+servers:
+{{- $servers := split "," $serversInput -}}
+{{- range $index, $server := $servers -}}
+  {{- $pairs := split ";" $server }}
+  - url: '{{ index $pairs 0 }}'
+    description: '{{ index $pairs 1 }}'
+{{- end }}
+{{- end }}
 components:
   schemas:
     {{- range $_, $error := $webrpcErrors }}


### PR DESCRIPTION
```
	webrpc-gen \
	-schema=proto/indexer.ridl \
	-target=../../Webrpc/gen-openapi \
	-title=Indexer \
	-serverUrl="http://localhost:9000" \
	-serverDescription="Description for server" \
	-servers="http://localhost:8080;description,http://localhost:8081;more description,http://localhost:8082;" \
	-out=./docs/indexer.gen.yaml
```

- it's backward compatible