### PR TITLE
generate operation id

### DIFF
--- a/_examples/openapi.gen.yaml
+++ b/_examples/openapi.gen.yaml
@@ -501,6 +501,7 @@ components:
 paths:
   /rpc/ExampleService/Ping:
     post:
+      operationId: ExampleServicePing
       tags: ["ExampleService"]
       summary: "Deprecated."
       deprecated: true
@@ -542,6 +543,7 @@ paths:
                 - $ref: '#/components/schemas/ErrorDatabaseDown'
   /rpc/ExampleService/GetUser:
     post:
+      operationId: ExampleServiceGetUser
       tags: ["ExampleService"]
       summary: "Deprecated: Use GetUserV2 instead."
       deprecated: true
@@ -585,6 +587,7 @@ paths:
                 - $ref: '#/components/schemas/ErrorDatabaseDown'
   /rpc/ExampleService/GetUserV2:
     post:
+      operationId: ExampleServiceGetUserV2
       tags: ["ExampleService"]
       summary: "GetUserV2 returns user based on given userID."
       security:
@@ -629,6 +632,7 @@ paths:
                 - $ref: '#/components/schemas/ErrorDatabaseDown'
   /rpc/ExampleService/FindUser:
     post:
+      operationId: ExampleServiceFindUser
       tags: ["ExampleService"]
       summary: "FindUser searches for a user using the given search filter."
       security:
@@ -676,6 +680,7 @@ paths:
                 - $ref: '#/components/schemas/ErrorDatabaseDown'
   /rpc/ExampleService/ListUsers:
     post:
+      operationId: ExampleServiceListUsers
       tags: ["ExampleService"]
       summary: "ListUsers returns all users."
       security:
@@ -718,6 +723,7 @@ paths:
                 - $ref: '#/components/schemas/ErrorDatabaseDown'
   /rpc/ExampleService/GetComplex:
     post:
+      operationId: ExampleServiceGetComplex
       tags: ["ExampleService"]
       summary: ""
       requestBody:
@@ -758,6 +764,7 @@ paths:
                 - $ref: '#/components/schemas/ErrorDatabaseDown'
   /rpc/ExampleService/GetAllOptional:
     post:
+      operationId: ExampleServiceGetAllOptional
       tags: ["ExampleService"]
       summary: ""
       requestBody:
@@ -798,6 +805,7 @@ paths:
                 - $ref: '#/components/schemas/ErrorDatabaseDown'
   /rpc/AdminService/ListUsers:
     post:
+      operationId: AdminServiceListUsers
       tags: ["AdminService"]
       summary: ""
       security:

--- a/_examples/openapi.gen.yaml
+++ b/_examples/openapi.gen.yaml
@@ -501,7 +501,7 @@ components:
 paths:
   /rpc/ExampleService/Ping:
     post:
-      operationId: ExampleServicePing
+      operationId: ExampleService-Ping
       tags: ["ExampleService"]
       summary: "Deprecated."
       deprecated: true
@@ -543,7 +543,7 @@ paths:
                 - $ref: '#/components/schemas/ErrorDatabaseDown'
   /rpc/ExampleService/GetUser:
     post:
-      operationId: ExampleServiceGetUser
+      operationId: ExampleService-GetUser
       tags: ["ExampleService"]
       summary: "Deprecated: Use GetUserV2 instead."
       deprecated: true
@@ -587,7 +587,7 @@ paths:
                 - $ref: '#/components/schemas/ErrorDatabaseDown'
   /rpc/ExampleService/GetUserV2:
     post:
-      operationId: ExampleServiceGetUserV2
+      operationId: ExampleService-GetUserV2
       tags: ["ExampleService"]
       summary: "GetUserV2 returns user based on given userID."
       security:
@@ -632,7 +632,7 @@ paths:
                 - $ref: '#/components/schemas/ErrorDatabaseDown'
   /rpc/ExampleService/FindUser:
     post:
-      operationId: ExampleServiceFindUser
+      operationId: ExampleService-FindUser
       tags: ["ExampleService"]
       summary: "FindUser searches for a user using the given search filter."
       security:
@@ -680,7 +680,7 @@ paths:
                 - $ref: '#/components/schemas/ErrorDatabaseDown'
   /rpc/ExampleService/ListUsers:
     post:
-      operationId: ExampleServiceListUsers
+      operationId: ExampleService-ListUsers
       tags: ["ExampleService"]
       summary: "ListUsers returns all users."
       security:
@@ -723,7 +723,7 @@ paths:
                 - $ref: '#/components/schemas/ErrorDatabaseDown'
   /rpc/ExampleService/GetComplex:
     post:
-      operationId: ExampleServiceGetComplex
+      operationId: ExampleService-GetComplex
       tags: ["ExampleService"]
       summary: ""
       requestBody:
@@ -764,7 +764,7 @@ paths:
                 - $ref: '#/components/schemas/ErrorDatabaseDown'
   /rpc/ExampleService/GetAllOptional:
     post:
-      operationId: ExampleServiceGetAllOptional
+      operationId: ExampleService-GetAllOptional
       tags: ["ExampleService"]
       summary: ""
       requestBody:
@@ -805,7 +805,7 @@ paths:
                 - $ref: '#/components/schemas/ErrorDatabaseDown'
   /rpc/AdminService/ListUsers:
     post:
-      operationId: AdminServiceListUsers
+      operationId: AdminService-ListUsers
       tags: ["AdminService"]
       summary: ""
       security:

--- a/main.go.tmpl
+++ b/main.go.tmpl
@@ -134,7 +134,7 @@ paths:
   {{- $deprecated := index $method.Annotations "deprecated" }}
   /rpc/{{$service.Name}}/{{$method.Name}}:
     post:
-      operationId: {{$service.Name}}{{$method.Name}}
+      operationId: {{$service.Name}}-{{$method.Name}}
       tags: ["{{$service.Name}}"]
       summary: {{ if $deprecated }}{{ if $deprecated.Value }}{{printf "%q" (print "Deprecated: " $deprecated.Value)}}{{else}}"Deprecated."{{end}}{{else if gt (len $method.Comments) 0}}{{printf "%q" (index $method.Comments 0)}}{{else}}""{{end}}
       {{- if $deprecated }}

--- a/main.go.tmpl
+++ b/main.go.tmpl
@@ -134,6 +134,7 @@ paths:
   {{- $deprecated := index $method.Annotations "deprecated" }}
   /rpc/{{$service.Name}}/{{$method.Name}}:
     post:
+      operationId: {{$service.Name}}{{$method.Name}}
       tags: ["{{$service.Name}}"]
       summary: {{ if $deprecated }}{{ if $deprecated.Value }}{{printf "%q" (print "Deprecated: " $deprecated.Value)}}{{else}}"Deprecated."{{end}}{{else if gt (len $method.Comments) 0}}{{printf "%q" (index $method.Comments 0)}}{{else}}""{{end}}
       {{- if $deprecated }}


### PR DESCRIPTION
- operationId: method name or combination service name and method name to make it unique

`operationId` is an optional unique string used to identify an operation. If provided, these IDs must be unique among all operations described in your API

Reasons to add this: 

- Some code generators use this value to name the corresponding methods in code.
- Links can refer to the linked operations by operationId.