### PR TITLE
ci: add workflow to notify main repo on new tag

### DIFF
--- a/.github/workflows/notify-main.yml
+++ b/.github/workflows/notify-main.yml
@@ -1,0 +1,18 @@
+name: Notify main repo
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to webrpc/webrpc
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GH_TOKEN_GIT_COMMIT }}
+          repository: webrpc/webrpc
+          event-type: generator-updated
+          client-payload: '{"generator": "gen-openapi", "version": "${{ github.ref_name }}"}'


### PR DESCRIPTION
## Summary

- Adds `notify-main.yml` workflow that dispatches a `generator-updated` event to webrpc/webrpc when a `v*` tag is pushed
- This triggers webrpc's `bump-generator.yml` to automatically update go.mod

## Test plan

- [ ] Push a `v*` tag and verify the dispatch fires