### PR TITLE
docs(readme): document -schemaHash option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Change any of the following default values by passing `-option="Value"` CLI flag
 | `-servers`             | `""`                     | `http://localhost:8080;description,http://localhost:8081;description`                                                                |
 | `-securityAnnotation`  | `""`                     | `@auth`                                                                                                                              |
 | `-securitySchemes`     | `""`                     | `{"ApiKeyAuth":{"type":"apiKey", "in":"header", "description":"Access key for authenticating requests", "name":"X-Access-Key"}}`     | 
+| `-schemaHash`          | `true`                   | `false` (omit the schema hash from the header comment)                                                                                |
 
 
 Example:


### PR DESCRIPTION
The `-schemaHash` opt-out (default-on) was missing from the README options table, so it was undiscoverable unless you read the template. This adds the missing row. (`-help` already lists it — that output is generated from the opts dict — so only the hand-maintained table needed updating.)

---

Docs-only; no template or generated-code change. `-schemaHash=false` omits the schema hash + version consts from the generated output, which removes the per-edit hash churn that causes merge conflicts.

Part of a sweep documenting this flag across the generators (gen-golang webrpc/gen-golang#122 already up).
